### PR TITLE
Update to libc v0.2

### DIFF
--- a/opus-sys/Cargo.toml
+++ b/opus-sys/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "opus-sys"
-version = "0.1.2"
+version = "0.2.0"
 authors = ["Tero Hänninen <lgvz@users.noreply.github.com>"]
 description = "Bindings to libopus"
 license = "MIT"
@@ -10,7 +10,7 @@ links = "opus"
 build = "build.rs"
 
 [dependencies]
-libc = "0.1"
+libc = "0.2"
 
 [build-dependencies]
 pkg-config = "*"

--- a/opusfile-sys/Cargo.toml
+++ b/opusfile-sys/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "opusfile-sys"
-version = "0.1.1"
+version = "0.2.0"
 authors = ["Tero Hänninen <lgvz@users.noreply.github.com>"]
 description = "Bindings to libopusfile"
 license = "MIT"
@@ -10,7 +10,7 @@ links = "opusfile"
 build = "build.rs"
 
 [dependencies]
-libc = "0.1"
+libc = "0.2"
 ogg-sys = "*"
 opus-sys = "*"
 


### PR DESCRIPTION
Libc v0.1 is a little outdated, and mismatches the standard library's libc on some platforms (e.g. on ARM, c_char is i8 in 0.1, and u8 in 0.2 and std, causing problems). Feel free to move the opus-sys and opusfile-sys version bumps to another commit if you like; I included them because it's my understanding that bumping an exposed dependency like this requires bumping the crate itself.

opus-sys builds fine for me on Windows with this change, but I haven't tested opusfile-sys before or after.